### PR TITLE
Di 1993

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -7,17 +7,17 @@
   "dxapi": "1.0.0",
   "inputSpec": [
     {
-      "name": "input_bam",
-      "label": "Input BAM file",
-      "help": "The ID of an 'unrefined' BAM file for contamination checking",
+      "name": "input_file",
+      "label": "Input file",
+      "help": "The ID of BAM or CRAM file for contamination checking",
       "class": "file",
       "patterns": ["*.bam", "*.cram"],
       "optional": false
     },
     {
-      "name": "input_bam_index",
-      "label": "Index of input BAM",
-      "help": "The index file corresponding to the input BAM file",
+      "name": "input_file_index",
+      "label": "Index of input file",
+      "help": "The index file corresponding to the input BAM or CRAM file",
       "class": "file",
       "patterns": ["*.bai", "*.crai"],
       "optional": false
@@ -40,7 +40,7 @@
       "patterns": [
         "*.fa.fai"
       ],
-      "help": "Index reference file to align CRAM file to"
+      "help": "Index reference file to align CRAM file to. Required if CRAM given"
     },
     {
       "name": "vcf_file",

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,9 +1,9 @@
 {
   "name": "eggd_verifybamid", 
-  "title": "verifyBamID",
-  "summary": "v2.2.1 - Detects sample contamination from genotypic profiles; forked from moka-guys v1.2.0",
-  "version": "2.2.1",
-  "whatsNew": "* v2.2.1 Add licence file and update instance type;",
+  "title": "eggd_verifyBamID",
+  "summary": "v2.3.0 - Detects sample contamination from genotypic profiles; forked from moka-guys v1.2.0",
+  "version": "2.3.0",
+  "whatsNew": "* v2.3.0 Add ability to take cram as an input;",
   "dxapi": "1.0.0",
   "inputSpec": [
     {
@@ -11,7 +11,7 @@
       "label": "Input BAM file",
       "help": "The ID of an 'unrefined' BAM file for contamination checking",
       "class": "file",
-      "patterns": ["*.bam"],
+      "patterns": ["*.bam", "*.cram"],
       "optional": false
     },
     {
@@ -19,8 +19,28 @@
       "label": "Index of input BAM",
       "help": "The index file corresponding to the input BAM file",
       "class": "file",
-      "patterns": ["*.bai"],
+      "patterns": ["*.bai", "*.crai"],
       "optional": false
+    },
+    {
+      "name": "reference_fasta",
+      "label": "fasta file",
+      "class": "file",
+      "optional": true,
+      "patterns": [
+        "*.fa.gz"
+      ],
+      "help": "reference file to align CRAM file to"
+    },
+    {
+      "name": "reference_fasta_index",
+      "label": "fasta index file",
+      "class": "file",
+      "optional": true,
+      "patterns": [
+        "*.fa.fai"
+      ],
+      "help": "Index reference file to align CRAM file to"
     },
     {
       "name": "vcf_file",
@@ -45,6 +65,17 @@
     "distribution": "Ubuntu",
     "release": "20.04",
     "version": "0",
+    "assetDepends": [
+      {
+          "id": "record-Gg2GP0Q4zJKFz8gP3Gf4Q11v"
+      },
+      {
+          "name": "samtools_asset",
+          "version": "2.0.0",
+          "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+          "folder": "/app_assets/samtools/samtools_v1.19.2/"
+      }
+    ],
     "file": "src/code.sh",
     "timeoutPolicy": {
       "*": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_verifyBamID",
   "summary": "v2.3.0 - Detects sample contamination from genotypic profiles; forked from moka-guys v1.2.0",
   "version": "2.3.0",
-  "whatsNew": "* v2.3.0 Add ability to take cram as an input;",
+  "whatsNew": "*v2.2.1 Add licence file and update instance type; v2.3.0 Add ability to take cram as an input;",
   "dxapi": "1.0.0",
   "inputSpec": [
     {

--- a/src/code.sh
+++ b/src/code.sh
@@ -4,18 +4,21 @@
 # and to output each line as it is executed -- useful for debugging
 set -e -x -o pipefail
 
-dx download "$input_bam" -o "$input_bam_name"
-dx download "$input_bam_index" -o "$input_bam_index_name"
+dx download "$input_file" -o "$input_file_name"
+dx download "$input_file_index" -o "$input_file_index_name"
 dx download "$vcf_file" -o "$vcf_file_name"
 
 # if input_bam_name == cram, convert to bam and reindex
-if [[ $input_bam_name == *.cram ]]; then
-     echo "file is CRAM"
+if [[ $input_file_name == *.cram ]]; then
+     echo "Input is CRAM – converting to BAM"
+
+     [[ -z ${reference_fasta:-} || -z ${reference_fasta_index:-} ]] && \
+         { echo "ERROR: reference_fasta and reference_fasta_index are mandatory for CRAM input" >&2; exit 1; }
 
      dx download "$reference_fasta" -o "$reference_fasta_name"
      dx download "$reference_fasta_index" -o "$reference_fasta_index_name"
-     samtools view -b -T "$reference_fasta_name" -o "$input_bam_prefix".bam "$input_bam_name"
-     samtools index "$input_bam_prefix".bam
+     samtools view -b -T "$reference_fasta_name" -o "$input_file_prefix".bam "$input_file_name"
+     samtools index "$input_file_prefix".bam
 
 fi
 
@@ -27,8 +30,8 @@ mkdir -p out/verifybamid_out/
 # --precise; calculate the likelihood in log-scale for high-depth data (recommended when --maxDepth is greater than 20)
 # --maxDepth 1000; For the targeted exome sequencing, --maxDepth 1000 and --precise is recommended.
 verifyBamID --vcf $vcf_file_name \
-     --bam $input_bam_prefix.bam \
-     --out out/verifybamid_out/$input_bam_prefix \
+     --bam $input_file_prefix.bam \
+     --out out/verifybamid_out/$input_file_prefix \
      --verbose --ignoreRG --precise --maxDepth 1000
 
 # Upload results to DNAnexus

--- a/src/code.sh
+++ b/src/code.sh
@@ -5,8 +5,24 @@
 set -e -x -o pipefail
 
 dx download "$input_bam" -o "$input_bam_name"
-dx download "$input_bam_index" -o "${input_bam_prefix}.bai"
+dx download "$input_bam_index" -o "$input_bam_index_name"
 dx download "$vcf_file" -o "$vcf_file_name"
+
+
+# if input_bam_name == cram, convert to bam and reindex?, then use input_bam_prefix.bam later
+
+if [[ $input_bam_name == *.cram ]]; then
+     echo "file is CRAM"
+
+     # to add - try, if file does not exist then error with "reference fasta needed for cram"
+     dx download "$reference_fasta" -o "$reference_fasta_name"
+     dx download "$reference_fasta_index" -o "$reference_fasta_index_name"
+     samtools view -b -T "$reference_fasta_name" -o "$input_bam_prefix".bam "$input_bam_name"
+     samtools index "$input_bam_prefix".bam
+
+fi
+
+
 
 # Create output directory
 mkdir -p out/verifybamid_out/
@@ -16,7 +32,7 @@ mkdir -p out/verifybamid_out/
 # --precise; calculate the likelihood in log-scale for high-depth data (recommended when --maxDepth is greater than 20)
 # --maxDepth 1000; For the targeted exome sequencing, --maxDepth 1000 and --precise is recommended.
 verifyBamID --vcf $vcf_file_name \
-     --bam $input_bam_name \
+     --bam $input_bam_prefix.bam \
      --out out/verifybamid_out/$input_bam_prefix \
      --verbose --ignoreRG --precise --maxDepth 1000
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -8,21 +8,16 @@ dx download "$input_bam" -o "$input_bam_name"
 dx download "$input_bam_index" -o "$input_bam_index_name"
 dx download "$vcf_file" -o "$vcf_file_name"
 
-
-# if input_bam_name == cram, convert to bam and reindex?, then use input_bam_prefix.bam later
-
+# if input_bam_name == cram, convert to bam and reindex
 if [[ $input_bam_name == *.cram ]]; then
      echo "file is CRAM"
 
-     # to add - try, if file does not exist then error with "reference fasta needed for cram"
      dx download "$reference_fasta" -o "$reference_fasta_name"
      dx download "$reference_fasta_index" -o "$reference_fasta_index_name"
      samtools view -b -T "$reference_fasta_name" -o "$input_bam_prefix".bam "$input_bam_name"
      samtools index "$input_bam_prefix".bam
 
 fi
-
-
 
 # Create output directory
 mkdir -p out/verifybamid_out/


### PR DESCRIPTION
add ability for verifyBamID to take CRAM files

If a cram file is given as an input, use samtools to convert this to a bam file and then reindex
- samtools requires reference file is given to convert cram to bam, so added optional inputs for reference fasta file
- renamed input_bam to  input_file, as bam or cram can be given

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_verifybamid/9)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for CRAM files as input, alongside BAM files.
  * Introduced optional inputs for reference FASTA and its index to enable CRAM file processing.

* **Chores**
  * Updated application metadata, including title, version, and summary to reflect new capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->